### PR TITLE
tim/comparison fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "lpm-discretize"
+version = "0.0.1"
+description = "A library for discretizing dataframes and csv files"
+license = "Apache-2.0"
+authors = ["Ulli Schaechtle <ulli@mit.edu>","Tim Burress <tim-burress@garage.co.jp>"]
+readme = "README.md"
+packages = [{include = "lpm_discretize",from = "src"}]
+repository = "https://github.com/inferenceql/lpm.discretize"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+numpy = "^2.1.1"
+polars = "^1.7.1"
+
+[tools.poetry.group.test.dependencies]
+pytest = "^8.3.3"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/src/lpm_discretize/__init__.py
+++ b/src/lpm_discretize/__init__.py
@@ -1,0 +1,11 @@
+# src/foo/__init__.py
+
+# Import
+from .discretize import *
+
+# Explicitly import those two for testing (it' seems Python is trying
+# to be smart when running import * and not actually import internal
+# functions. We still want to test them, though.
+from .discretize import _is_number
+from .discretize import _prefix_category_name
+from .discretize import _readable_category_name

--- a/src/lpm_discretize/discretize.py
+++ b/src/lpm_discretize/discretize.py
@@ -102,7 +102,7 @@ def get_quantile_based_discretization_function(column, quantiles=4, decimals=1):
         set(
             [
                 quantile["breakpoint"]
-                for quantile in pl.Series(column).qcut(quantiles, include_breaks=True)
+                for quantile in pl.Series(column).qcut(quantiles, include_breaks=True, allow_duplicates=True)
             ]
         )
     )
@@ -111,7 +111,7 @@ def get_quantile_based_discretization_function(column, quantiles=4, decimals=1):
         assert not isinstance(value, str)
         if _is_number(value):
             for i, cutoff in enumerate(cutoffs[:-1]):
-                if value < cutoff:
+                if value <= cutoff:
                     if i == 0:
                         return _prefix_category_name(
                             i, len(cutoffs)

--- a/src/lpm_discretize/discretize.py
+++ b/src/lpm_discretize/discretize.py
@@ -1,0 +1,449 @@
+import numbers
+import numpy as np
+import polars as pl
+import string
+
+_QUALITATIVE_LABELS = {
+    2: ["low", "high"],
+    3: ["low", "medium", "high"],
+    4: ["very low", "low", "high", "very high"],
+    5: ["very low", "low", "medium", "high", "very high"],
+}
+
+
+def _prefix_category_name(idx, total_number_categories):
+    """
+    Description:
+        Create a prefix for readable category name based on an index and
+        the total number of categories.
+
+    Parameters:
+        - idx (int):  will translate to a letter.
+        - total_number_categories:  decides on whether to add qualitiative
+          labels like "high"/"low". Needs to be larger than 1. If larger than
+          5, no labels are supplied.
+    Returns:
+        A string that will be used as a prefix for categorical.
+    """
+    assert idx is not None
+    assert total_number_categories is not None
+    assert total_number_categories > 1
+
+    lower_case_letters = string.ascii_lowercase
+    # Check if the category-index is larger that 26 and hence if
+    # we can assign a letter for enhance readability.
+    if idx < len(lower_case_letters):
+        letter = f"({lower_case_letters[idx]})"
+    else:
+        return ""
+    if total_number_categories <= 5:
+        label = _QUALITATIVE_LABELS[total_number_categories][idx] + " "
+    else:
+        label = ""
+    return f"{letter} {label}"
+
+
+def _readable_category_name(lower_bound=None, upper_bound=None, decimals=1):
+    """
+    Description:
+        Create a readable category name based on upper and lower bounds.
+
+    Parameters:
+    - lower_bound (float): lower bound of the category.
+    - upper_bound (float): upper bound of the category.
+    - decimals (int): ensure not more than n decimals are printed.
+
+    Returns:
+        A string with a readable category name, including an alphabetical index,
+        if index is <= 26 (index > 26 should be a rare case for bound-based
+        categorization; so having it work - yet slightly less readable seems
+        fine).
+    """
+    assert (lower_bound is not None) or (upper_bound is not None)
+    if lower_bound is None:
+        return f"(> {upper_bound:.{decimals}f})"
+    elif upper_bound is None:
+        return f"(≤ {lower_bound:.{decimals}f})"
+    else:
+        assert lower_bound < upper_bound
+        return f"({lower_bound:.{decimals}f} - {upper_bound:.{decimals}f})"
+
+
+def _is_number(value):
+    """None/np.nan robust checking for numerical values."""
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return False
+    if np.isnan(value):
+        return False
+    return isinstance(value, numbers.Number)
+
+
+def get_quantile_based_discretization_function(column, quantiles=4, decimals=1):
+    """
+    Description:
+        Takes a reference column that downn the road needs to be discretized and
+        returns a function can be used for that. Relies on Polar's qcut
+        discretization but retuns a function that can easily be re-used
+        and returns human-readable output.
+
+    Parameters:
+    - colummn (Polars series or list):  A sequence
+    - quantile (int): The number of quantiles used for discretization (default =
+      4).
+
+    Returns:
+        A function that can be applied to a column for discretization.
+    """
+    column = [value for value in column if _is_number(value)]
+    assert len(set(column)) > 1
+    cutoffs = sorted(
+        set(
+            [
+                quantile["breakpoint"]
+                for quantile in pl.Series(column).qcut(quantiles, include_breaks=True)
+            ]
+        )
+    )
+
+    def _discretization_function(value):
+        assert not isinstance(value, str)
+        if _is_number(value):
+            for i, cutoff in enumerate(cutoffs[:-1]):
+                if value < cutoff:
+                    if i == 0:
+                        return _prefix_category_name(
+                            i, len(cutoffs)
+                        ) + _readable_category_name(
+                            lower_bound=cutoff, upper_bound=None, decimals=decimals
+                        )
+                    else:
+                        return _prefix_category_name(
+                            i, len(cutoffs)
+                        ) + _readable_category_name(
+                            lower_bound=cutoffs[i - 1],
+                            upper_bound=cutoff,
+                            decimals=decimals,
+                        )
+            return _prefix_category_name(
+                len(cutoffs) - 1, len(cutoffs)
+            ) + _readable_category_name(
+                lower_bound=None, upper_bound=cutoffs[i], decimals=decimals
+            )
+
+    return _discretization_function
+
+
+def discretize_column(column, discretization_function):
+    """
+    Description:
+        Discretize a numerical column
+
+    Parameters:
+    - colummn (Polars series or list):  A sequence
+    - discretization_function (function): A functoin that processes the numerical values and
+                                          discretizes them.
+
+    Returns:
+        A new list with discretized values
+
+    Examples:
+    >>> discretize_column([1,2,1], lambda x: "yes" if x <= 1 else "no")
+        ["yes", "no", "yes"]
+    """
+
+    # In order for this function to be useful, it needs to:
+    #   1. Fail loudly if a string is supplied.
+    #   2. Deal gracefully with None/np.nan.
+    def _safe_discretization(value):
+        assert not isinstance(value, str)
+        if _is_number(value):
+            return discretization_function(value)
+
+    return [_safe_discretization(value) for value in column]
+
+
+def discretize_df(df, discretization_functions):
+    """
+    Description:
+        Discretize all numerical columns in a Polars dataframe.
+
+    Parameters:
+    - df (Polars dataframe):  A Polars dataframe for which a subset of columns
+                              need to be discretized.
+    - discretization_functions (dict):
+        - a dict from column name to functions, to apply different
+          discretization schemes for different columns.
+
+    Returns:
+        A new Polars dataframe, where numerical columns are discretized.
+
+    Examples:
+    >>> print(df)
+        ┌─────┬─────┬─────┬─────┐
+        │ foo ┆ bar ┆ ... ┆ baz │
+        │ --- ┆ --- ┆ --- ┆ --- │
+        │ f64 ┆ i64 ┆ ... ┆ str │
+        ╞═════╪═════╪═════╪═════╡
+        │ 1.0 ┆ 8   ┆ ... ┆ x   │
+        │ 2.0 ┆ 7   ┆ ... ┆ y   │
+        │ 3.0 ┆ 6   ┆ ... ┆ x   │
+        │ 4.0 ┆ 5   ┆ ... ┆ x   │
+        └─────┴─────┴─────┴─────┘
+
+    >>> discretize(df, discretization_functions={
+        "foo": lambda x: "yes" if x <= 1 else "no",
+        "bar": lambda x: "ja" if x <= 6 else "nein"})
+        ┌───────┬────────┬─────┬─────┐
+        │ foo   ┆ bar    ┆ ... ┆ baz │
+        │ ---   ┆ ---    ┆ --- ┆ --- │
+        │ str   ┆ str    ┆ ... ┆ str │
+        ╞═══════╪════════╪═════╪═════╡
+        │ "yes" ┆ "nein" ┆ ... ┆ x   │
+        │ "no"  ┆ "nein" ┆ ... ┆ y   │
+        │ "no"  ┆ "ja"   ┆ ... ┆ x   │
+        │ "no"  ┆ "ja"   ┆ ... ┆ x   │
+        └───────┴────────┴─────┴─────┘
+    """
+
+    def _apply_discretization_where_needed(c):
+        """Helper function to make list comprehension below more readable."""
+        if c in discretization_functions:
+            return discretize_column(df[c], discretization_functions[c])
+        else:
+            return df[c]
+
+    return pl.DataFrame({c: _apply_discretization_where_needed(c) for c in df.columns})
+
+
+def _set_quantiles(quantiles, columns):
+    """Set default value for number of quantiles safely."""
+    if quantiles is None:
+        quantiles = 4
+    if isinstance(quantiles, int):
+        quantiles = {c: quantiles for c in columns}
+    elif isinstance(quantiles, dict):
+        assert set(quantiles.keys()).issubset(set(columns))
+    else:
+        raise ValueError(quantiles)
+    return quantiles
+
+
+def discretize_df_quantiles(df, quantiles=4, columns=None, decimals=1):
+    """
+    Description:
+        Discretize numerical columns in a Polars dataframe.
+
+    Parameters:
+    - df (Polars dataframe):  A Polars dataframe for which a subset of columns
+                              need to be discretized.
+    - quantiles (dict | int): Either
+                                - an int showing how many quartiles to use
+                                - dict from column name to functions, to apply
+                                  different discretization schemes for different columns.
+    - columns:  A list indicating which columns to discretized.  Defaulting to
+                Polar's types.
+
+    Returns:
+        A new Polars dataframe, where numerical columns are discretized.
+
+    Examples:
+    >>> print(df)
+        ┌─────┬─────┬─────┬─────┐
+        │ foo ┆ bar ┆ ... ┆ baz │
+        │ --- ┆ --- ┆ --- ┆ --- │
+        │ f64 ┆ i64 ┆ ... ┆ str │
+        ╞═════╪═════╪═════╪═════╡
+        │ 1.0 ┆ 8   ┆ ... ┆ x   │
+        │ 2.0 ┆ 7   ┆ ... ┆ y   │
+        │ 3.0 ┆ 6   ┆ ... ┆ x   │
+        │ 4.0 ┆ 5   ┆ ... ┆ x   │
+        └─────┴─────┴─────┴─────┘
+
+    >>> discretize_df_quantiles(df, quantiles=4)
+        ┌─────────────────────────┬──────────────────────────┬─────┬─────┐
+        │ foo                     ┆ bar                      ┆ ... ┆ baz │
+        │ ---                     ┆ ---                      ┆ --- ┆ --- │
+        │ str                     ┆ str                      ┆ ... ┆ str │
+        ╞═════════════════════════╪══════════════════════════╪═════╪═════╡
+        │ "(a) Very Low (≤ 1.75)" ┆ "(d) Very High (> 7.25)" ┆ ... ┆ x   │
+        │ "(b) Low (1.75 - 2.5)"  ┆ "(c) High (6.5 - 7.25)"  ┆ ... ┆ y   │
+        │ "(c) High (2.5 - 3.25)" ┆ "(b) Low (5.75 - 6.5)"   ┆ ... ┆ x   │
+        │ "(d) Very High (> 3.25)"┆ "(a) Very Low (≤ 5.75)"  ┆ ... ┆ x   │
+        └─────────────────────────┴──────────────────────────┴─────┴─────┘,
+
+    >>> discretize_df_quantiles(df, quantiles=2)
+        ┌────────────┬────────────┬─────┬─────┐
+        │ foo        ┆ bar        ┆ ... ┆ baz │
+        │ ---        ┆ ---        ┆ --- ┆ --- │
+        │ str        ┆ str        ┆ ... ┆ str │
+        ╞════════════╪════════════╪═════╪═════╡
+        │ "(a) low"  ┆ "(b) high" ┆ ... ┆ x   │
+        │ "(b) high" ┆ "(b) high" ┆ ... ┆ y   │
+        │ "(b) high" ┆ "(a) low"  ┆ ... ┆ x   │
+        │ "(b) high" ┆ "(a) low"  ┆ ... ┆ x   │
+        └────────────┴────────────┴─────┴─────┘
+    """
+    # Set default values for the columns we want to discretize.
+    if columns is None:
+        columns = [c for c in df.columns if df[c].dtype.is_numeric()]
+
+    quantiles = _set_quantiles(quantiles, columns)
+
+    return discretize_df(
+        df,
+        {
+            c: get_quantile_based_discretization_function(df[c], q, decimals)
+            for c, q in quantiles.items()
+        },
+    )
+
+
+def discretize_quantiles(
+    dataframes, reference_idx=0, quantiles=None, columns=None, decimals=1
+):
+    """
+    Description:
+        Discretize all numerical columns in a list of dataframes supplied. One
+        dataframe in the list is chosen as a reference for empirical
+        discretization, e.g. based on quantiles (see parameter reference_idx
+        below).
+
+    Parameters:
+    - dataframes (list):  A list of Polars dataframes.
+    - reference_idx (int): Which of these dataframes should be the reference point for
+      empirical discretization (e.g. based on quantiles).
+    - quantiles (dict | int): Either
+                                - an int showing how many quartiles to use
+                                - dict from column name to functions, to apply
+                                  different discretization schemes for different columns.
+    - columns:  A list indicating which columns to discretized.  Defaulting to
+                Polar's types.
+      (optional, default: Statistical types are guessed based on Polars' types).
+
+    Returns:
+        A list of Polars dataframes, where numerical columns are discretized.
+
+    Examples:
+    >>> print(dfs)
+        [
+            ┌─────┬─────┬─────┬─────┐
+            │ foo ┆ bar ┆ ... ┆ baz │
+            │ --- ┆ --- ┆ --- ┆ --- │
+            │ f64 ┆ i64 ┆ ... ┆ str │
+            ╞═════╪═════╪═════╪═════╡
+            │ 1.0 ┆ 8   ┆ ... ┆ x   │
+            │ 2.0 ┆ 7   ┆ ... ┆ y   │
+            │ 3.0 ┆ 6   ┆ ... ┆ x   │
+            │ 4.0 ┆ 5   ┆ ... ┆ x   │
+            └─────┴─────┴─────┴─────┘,
+            ┌─────┬─────┬─────┬─────┐
+            │ foo ┆ bar ┆ ... ┆ baz │
+            │ --- ┆ --- ┆ --- ┆ --- │
+            │ f64 ┆ i64 ┆ ... ┆ str │
+            ╞═════╪═════╪═════╪═════╡
+            │ 4.0 ┆ 5   ┆ ... ┆ z   │
+            │ 2.0 ┆ 7   ┆ ... ┆ y   │
+            │ 3.0 ┆ 6   ┆ ... ┆ z   │
+            │ 4.0 ┆ 5   ┆ ... ┆ x   │
+            └─────┴─────┴─────┴─────┘,
+            ...
+        ]
+
+    >>> discretize_quantiles(dfs)
+        [
+            ┌─────────────────────────┬──────────────────────────┬─────┬─────┐
+            │ foo                     ┆ bar                      ┆ ... ┆ baz │
+            │ ---                     ┆ ---                      ┆ --- ┆ --- │
+            │ str                     ┆ str                      ┆ ... ┆ str │
+            ╞═════════════════════════╪══════════════════════════╪═════╪═════╡
+            │ "(a) Very Low (≤ 1.75)" ┆ "(d) Very High (> 7.25)" ┆ ... ┆ x   │
+            │ "(b) Low (1.75 - 2.5)"  ┆ "(c) High (6.5 - 7.25)"  ┆ ... ┆ y   │
+            │ "(c) High (2.5 - 3.25)" ┆ "(b) Low (5.75 - 6.5)"   ┆ ... ┆ x   │
+            │ "(d) Very High (> 3.25)"┆ "(a) Very Low (≤ 5.75)"  ┆ ... ┆ x   │
+            └─────────────────────────┴──────────────────────────┴─────┴─────┘,
+            ┌─────────────────────────┬──────────────────────────┬─────┬─────┐
+            │ foo                     ┆ bar                      ┆ ... ┆ baz │
+            │ ---                     ┆ ---                      ┆ --- ┆ --- │
+            │ str                     ┆ str                      ┆ ... ┆ str │
+            ╞═════════════════════════╪══════════════════════════╪═════╪═════╡
+            │ "(d) Very High (> 3.25)"┆ "(a) Very Low (≤ 5.75)"  ┆ ... ┆ z   │
+            │ "(b) Low (1.75 - 2.5)"  ┆ "(c) High (6.5 - 7.25)"  ┆ ... ┆ y   │
+            │ "(c) High (2.5 - 3.25)" ┆ "(b) Low (5.75 - 6.5)"   ┆ ... ┆ z   │
+            │ "(d) Very High (> 3.25)"┆ "(a) Very Low (≤ 5.75)"  ┆ ... ┆ x   │
+            └─────────────────────────┴──────────────────────────┴─────┴─────┘,
+        ...
+        ]
+
+    >>> discretize_quantiles(dfs, quantiles=2)
+        [
+            ┌─────────────────────┬─────────────────────┬─────┬─────┐
+            │ foo                 ┆ bar                 ┆ ... ┆ baz │
+            │ ---                 ┆ ---                 ┆ --- ┆ --- │
+            │ str                 ┆ str                 ┆ ... ┆ str │
+            ╞═════════════════════╪═════════════════════╪═════╪═════╡
+            │ "(a) Low (≤ 2.5)"   ┆ "(b) High (> 6.5 )" ┆ ... ┆ x   │
+            │ "(a) Low (≤ 2.5)"   ┆ "(b) High (> 6.5 )" ┆ ... ┆ y   │
+            │ "(b) High (> 2.5 )" ┆ "(a) Low (≤ 2.5)"   ┆ ... ┆ x   │
+            │ "(b) High (> 2.5 )" ┆ "(a) Low (≤ 2.5)"   ┆ ... ┆ x   │
+            └─────────────────────┴─────────────────────┴─────┴─────┘,
+            ┌─────────────────────┬─────────────────────┬─────┬─────┐
+            │ foo                 ┆ bar                 ┆ ... ┆ baz │
+            │ ---                 ┆ ---                 ┆ --- ┆ --- │
+            │ str                 ┆ str                 ┆ ... ┆ str │
+            ╞═════════════════════╪═════════════════════╪═════╪═════╡
+            │ "(b) High (> 2.5 )" ┆ "(a) Low (≤ 2.5)"   ┆ ... ┆ x   │
+            │ "(a) Low (≤ 2.5)"   ┆ "(b) High (> 6.5 )" ┆ ... ┆ y   │
+            │ "(b) High (> 2.5 )" ┆ "(a) Low (≤ 2.5)"   ┆ ... ┆ x   │
+            │ "(b) High (> 2.5 )" ┆ "(a) Low (≤ 2.5)"   ┆ ... ┆ x   │
+            └─────────────────────┴─────────────────────┴─────┴─────┘,
+        ...
+        ]
+
+    >>> discretize_quantiles(dfs, quantiles={"foo":4, "bar":2})
+        [
+            ┌─────────────────────────┬─────────────────────┬─────┬─────┐
+            │ foo                     ┆ bar                 ┆ ... ┆ baz │
+            │ ---                     ┆ ---                 ┆ --- ┆ --- │
+            │ str                     ┆ str                 ┆ ... ┆ str │
+            ╞═════════════════════════╪═════════════════════╪═════╪═════╡
+            │ "(a) Very Low (≤ 1.75)" ┆ "(b) High (> 6.5 )" ┆ ... ┆ x   │
+            │ "(b) Low (1.75 - 2.5)"  ┆ "(b) High (> 6.5 )" ┆ ... ┆ y   │
+            │ "(c) High (2.5 - 3.25)" ┆ "(a) Low (≤ 2.5)"   ┆ ... ┆ x   │
+            │ "(d) Very High (> 3.25)"┆ "(a) Low (≤ 2.5)"   ┆ ... ┆ x   │
+            └─────────────────────────┴─────────────────────┴─────┴─────┘,
+            ┌─────────────────────────┬─────────────────────┬─────┬─────┐
+            │ foo                     ┆ bar                 ┆ ... ┆ baz │
+            │ ---                     ┆ ---                 ┆ --- ┆ --- │
+            │ str                     ┆ str                 ┆ ... ┆ str │
+            ╞═════════════════════════╪═════════════════════╪═════╪═════╡
+            │ "(d) Very High (> 3.25)"┆ "(a) Low (≤ 2.5)"   ┆ ... ┆ x   │
+            │ "(b) Low (1.75 - 2.5)"  ┆ "(b) High (> 6.5 )" ┆ ... ┆ y   │
+            │ "(c) High (2.5 - 3.25)" ┆ "(a) Low (≤ 2.5)"   ┆ ... ┆ x   │
+            │ "(d) Very High (> 3.25)"┆ "(a) Low (≤ 2.5)"   ┆ ... ┆ x   │
+            └─────────────────────────┴─────────────────────┴─────┴─────┘,
+        ...
+        ]
+    """
+    # Set default values for the columns we want to discretize.
+    if columns is None:
+        columns = [
+            c
+            for c in dataframes[reference_idx].columns
+            if dataframes[reference_idx][c].dtype.is_numeric()
+        ]
+    # Check that the columns agree.
+    for df in dataframes[1:]:
+        assert set(df.columns) == set(dataframes[0].columns)
+
+    quantiles = _set_quantiles(quantiles, columns)
+    discretization_functions = {
+        column_name: get_quantile_based_discretization_function(
+            dataframes[reference_idx][column_name],
+            quantiles=quantile_number,
+            decimals=decimals,
+        )
+        for column_name, quantile_number in quantiles.items()
+    }
+    return [discretize_df(df, discretization_functions) for df in dataframes]

--- a/tests/test_discretize.py
+++ b/tests/test_discretize.py
@@ -289,9 +289,9 @@ def test_discretize_column_with_get_quantile_based_discretization_function():
     f = get_quantile_based_discretization_function(column)
     assert discretize_column(column, f) == [
         "(a) very low (≤ 2.0)",
+        "(a) very low (≤ 2.0)",
         "(b) low (2.0 - 3.0)",
         "(c) high (3.0 - 4.0)",
-        "(d) very high (> 4.0)",
         "(d) very high (> 4.0)",  # that looks weird but is correct. See spot check above, too.
     ]
 
@@ -345,9 +345,9 @@ _df_expected = pl.DataFrame(
     {
         "foo": [
             "(a) very low (≤ 2.0)",
+            "(a) very low (≤ 2.0)",
             "(b) low (2.0 - 3.0)",
             "(c) high (3.0 - 4.0)",
-            "(d) very high (> 4.0)",
             "(d) very high (> 4.0)",
         ],
         "bar": _discrete_column,
@@ -430,16 +430,16 @@ def test_discretize_quantiles_spot_check_int_quartiles():
             {
                 "foo": [
                     "(a) very low (≤ 2.0)",
+                    "(a) very low (≤ 2.0)",
                     "(b) low (2.0 - 3.0)",
                     "(c) high (3.0 - 4.0)",
-                    "(d) very high (> 4.0)",
                     "(d) very high (> 4.0)",
                 ],
                 "bar": [
                     "(a) very low (≤ 6.0)",
+                    "(a) very low (≤ 6.0)",
                     "(b) low (6.0 - 7.0)",
                     "(c) high (7.0 - 8.0)",
-                    "(d) very high (> 8.0)",
                     "(d) very high (> 8.0)",
                 ],
                 "baz": _discrete_column,
@@ -449,15 +449,15 @@ def test_discretize_quantiles_spot_check_int_quartiles():
             {
                 "foo": [
                     "(d) very high (> 4.0)",
+                    "(a) very low (≤ 2.0)",
                     "(b) low (2.0 - 3.0)",
                     "(c) high (3.0 - 4.0)",
-                    "(d) very high (> 4.0)",
                 ],
                 "bar": [
                     "(a) very low (≤ 6.0)",
-                    "(c) high (7.0 - 8.0)",
                     "(b) low (6.0 - 7.0)",
-                    "(d) very high (> 8.0)",
+                    "(a) very low (≤ 6.0)",
+                    "(c) high (7.0 - 8.0)",
                 ],
                 "baz": _discrete_column[:-1],
             }
@@ -474,15 +474,15 @@ def test_discretize_quantiles_spot_check_quantiles_per_col():
             {
                 "foo": [
                     "(a) very low (≤ 2.0)",
+                    "(a) very low (≤ 2.0)",
                     "(b) low (2.0 - 3.0)",
                     "(c) high (3.0 - 4.0)",
-                    "(d) very high (> 4.0)",
                     "(d) very high (> 4.0)",
                 ],
                 "bar": [
                     "(a) low (≤ 7.0)",
                     "(a) low (≤ 7.0)",
-                    "(b) high (> 7.0)",
+                    "(a) low (≤ 7.0)",
                     "(b) high (> 7.0)",
                     "(b) high (> 7.0)",
                 ],
@@ -493,13 +493,13 @@ def test_discretize_quantiles_spot_check_quantiles_per_col():
             {
                 "foo": [
                     "(d) very high (> 4.0)",
+                    "(a) very low (≤ 2.0)",
                     "(b) low (2.0 - 3.0)",
                     "(c) high (3.0 - 4.0)",
-                    "(d) very high (> 4.0)",
                 ],
                 "bar": [
                     "(a) low (≤ 7.0)",
-                    "(b) high (> 7.0)",
+                    "(a) low (≤ 7.0)",
                     "(a) low (≤ 7.0)",
                     "(b) high (> 7.0)",
                 ],
@@ -509,3 +509,8 @@ def test_discretize_quantiles_spot_check_quantiles_per_col():
     ]
     assert_frame_equal(discretized_dfs[0], expected[0])
     assert_frame_equal(discretized_dfs[1], expected[1])
+
+def test_get_quantile_based_discretization_function_skewed():
+    column = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 20, 20]
+    f = get_quantile_based_discretization_function(column, quantiles=6)
+    assert f(0) == "(a) low (≤ 0.0)"

--- a/tests/test_discretize.py
+++ b/tests/test_discretize.py
@@ -1,0 +1,511 @@
+import numpy as np
+import polars as pl
+import pytest
+
+from inspect import isfunction
+from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_not_equal
+
+from lpm_discretize import get_quantile_based_discretization_function
+from lpm_discretize import _is_number
+from lpm_discretize import _prefix_category_name
+from lpm_discretize import _readable_category_name
+from lpm_discretize import discretize
+from lpm_discretize import discretize_column
+from lpm_discretize import discretize_df
+from lpm_discretize import discretize_df_quantiles
+from lpm_discretize import discretize_quantiles
+
+
+def _assert_raised_AssertionError(f, *args):
+    """Helper function testing that an AssertionError is raised."""
+    with pytest.raises(AssertionError) as exc_info:
+        f(*args)
+    assert exc_info.type == AssertionError
+
+
+def test_prefix_category_name_args_None():
+    _assert_raised_AssertionError(_prefix_category_name, 42, None)
+    _assert_raised_AssertionError(_prefix_category_name, None, 42)
+
+
+def test_prefix_category_name_args_one_category():
+    _assert_raised_AssertionError(_prefix_category_name, 0, 1)
+
+
+def test_prefix_category_name_empty_prefix():
+    # Set the total number of categories larger than threshold for supplying
+    # qualitative category names.
+    total_number_categories = (
+        27  # more categories than there are letters in the alphabet
+    )
+    assert (
+        _prefix_category_name(total_number_categories - 1, total_number_categories)
+        == ""
+    )
+
+
+def test_prefix_category_name_letters():
+    # Set the total number of categories larger than threshold for supplying
+    # qualitative category names.
+    total_number_categories = 6
+    assert _prefix_category_name(0, total_number_categories) == "(a) "
+    assert _prefix_category_name(1, total_number_categories) == "(b) "
+    assert _prefix_category_name(2, total_number_categories) == "(c) "
+
+
+def test_prefix_category_name_letters_and_2_categories():
+    total_number_categories = 2
+    assert _prefix_category_name(0, total_number_categories) == "(a) low "
+    assert _prefix_category_name(1, total_number_categories) == "(b) high "
+
+
+def test_prefix_category_name_letters_and_3_categories():
+    total_number_categories = 3
+    assert _prefix_category_name(0, total_number_categories) == "(a) low "
+    assert _prefix_category_name(1, total_number_categories) == "(b) medium "
+    assert _prefix_category_name(2, total_number_categories) == "(c) high "
+
+
+def test_prefix_category_name_letters_and_4_categories():
+    total_number_categories = 4
+    assert _prefix_category_name(0, total_number_categories) == "(a) very low "
+    assert _prefix_category_name(1, total_number_categories) == "(b) low "
+    assert _prefix_category_name(2, total_number_categories) == "(c) high "
+    assert _prefix_category_name(3, total_number_categories) == "(d) very high "
+
+
+def test_prefix_category_name_letters_and_5_categories():
+    total_number_categories = 5
+    assert _prefix_category_name(0, total_number_categories) == "(a) very low "
+    assert _prefix_category_name(1, total_number_categories) == "(b) low "
+    assert _prefix_category_name(2, total_number_categories) == "(c) medium "
+    assert _prefix_category_name(3, total_number_categories) == "(d) high "
+    assert _prefix_category_name(4, total_number_categories) == "(e) very high "
+
+
+def test_readable_category_name_both_None():
+    _assert_raised_AssertionError(_readable_category_name, None, None)
+
+
+def test_readable_category_name_lower_higher_upper():
+    _assert_raised_AssertionError(_readable_category_name, 42, 17)
+
+
+@pytest.mark.parametrize(
+    "upper, lower, expected_result",
+    [
+        (
+            17.0,
+            None,
+            "(≤ 17.0)",
+        ),
+        (
+            None,
+            17.0,
+            "(> 17.0)",
+        ),
+        (
+            17.0,
+            42.0,
+            "(17.0 - 42.0)",
+        ),
+        # Now use ints
+        (
+            17,
+            None,
+            "(≤ 17.0)",
+        ),
+        (
+            None,
+            17,
+            "(> 17.0)",
+        ),
+        (
+            17,
+            42,
+            "(17.0 - 42.0)",
+        ),
+    ],
+)
+def test_readable_category_name_without_specifying_decimals(
+    upper, lower, expected_result
+):
+    _readable_category_name(upper, lower) == expected_result
+
+
+@pytest.mark.parametrize(
+    "upper, lower, decimals, expected_result",
+    [
+        (
+            17.00,
+            None,
+            2,
+            "(≤ 17.00)",
+        ),
+        (
+            None,
+            17.00,
+            2,
+            "(> 17.00)",
+        ),
+        (
+            17.00,
+            42.00,
+            2,
+            "(17.00 - 42.00)",
+        ),
+        (
+            17.000,
+            None,
+            3,
+            "(≤ 17.000)",
+        ),
+        (
+            None,
+            17.000,
+            3,
+            "(> 17.000)",
+        ),
+        (
+            17.000,
+            42.000,
+            3,
+            "(17.000 - 42.000)",
+        ),
+    ],
+)
+def test_readable_category_name_with_specifying_decimals(
+    upper, lower, decimals, expected_result
+):
+    _readable_category_name(upper, lower, decimals=decimals) == expected_result
+
+
+@pytest.mark.parametrize("value", [None, np.nan, "x", "abc"])
+def test_is_not_number(value):
+    assert not _is_number(value)
+
+
+@pytest.mark.parametrize("value", [0, 1, 42.0, -1])
+def test_is_number(value):
+    assert _is_number(value)
+
+
+@pytest.mark.parametrize(
+    "invalid_column",
+    [
+        [],
+        [42],
+        [42, 42],
+        [42, None, 42],
+        [42, np.nan, 42],
+    ],
+)
+def test_get_quantile_based_discretization_function_invalid_input(invalid_column):
+    _assert_raised_AssertionError(
+        get_quantile_based_discretization_function, invalid_column
+    )
+
+
+def test_get_quantile_based_discretization_function_smoke():
+    assert isfunction(get_quantile_based_discretization_function(range(3)))
+
+
+@pytest.mark.parametrize("n_quantiles", range(2, 12))
+def test_get_quantile_based_discretization_function_lower(n_quantiles):
+    f = get_quantile_based_discretization_function(
+        range(1, n_quantiles + 2), quantiles=n_quantiles
+    )
+    if n_quantiles < 4:
+        assert f(-1) == "(a) low (≤ 2.0)"
+    elif n_quantiles < 6:
+        assert f(-1) == "(a) very low (≤ 2.0)"
+    else:
+        assert f(-1) == "(a) (≤ 2.0)"
+
+
+@pytest.mark.parametrize("n_quantiles_upper", range(6, 16))
+def test_get_quantile_based_discretization_function_upper(n_quantiles_upper):
+    f = get_quantile_based_discretization_function(
+        range(1, n_quantiles_upper + 2), quantiles=n_quantiles_upper
+    )
+    assert f(16)[4:] == f"(> {float(n_quantiles_upper)})"
+
+
+@pytest.mark.parametrize("missing_value", [np.nan, None])
+def test_get_quantile_based_discretization_function_in_presence_of_NaN(missing_value):
+    f = get_quantile_based_discretization_function([1, 2, 3], quantiles=2)
+    assert f(missing_value) is None
+
+
+def test_get_quantile_based_discretization_function_in_presence_of_str_value():
+    f = get_quantile_based_discretization_function([1, 2, 3, 4])
+    _assert_raised_AssertionError(f, "foo")
+
+
+def test_get_quantile_based_discretization_function_quartiles_spot_check():
+    f = get_quantile_based_discretization_function(range(5), quantiles=4)
+    assert f(2.5) == "(c) high (2.0 - 3.0)"
+
+
+def test_get_quantile_based_discretization_function_6_split_spot_check():
+    f = get_quantile_based_discretization_function(range(10), quantiles=5)
+    assert f(5) == "(c) medium (3.6 - 5.4)"
+
+
+def test_get_quantile_based_discretization_function_4_split_spot_check():
+    column = range(1, 6)
+    f = get_quantile_based_discretization_function(column)
+    assert f(column[-1]) == "(d) very high (> 4.0)"
+
+
+DISCRETIZE_BIN = lambda x: "yes" if x <= 1 else "no"
+
+
+def test_discretize_column_binary():
+    assert discretize_column([1, 2, 1], DISCRETIZE_BIN) == ["yes", "no", "yes"]
+
+
+def test_discretize_column_binary_None():
+    assert discretize_column([1, 2, None, 1], DISCRETIZE_BIN) == [
+        "yes",
+        "no",
+        None,
+        "yes",
+    ]
+
+
+def test_discretize_column_binary_np_nan():
+    assert discretize_column([1, 2, np.nan, 1], DISCRETIZE_BIN) == [
+        "yes",
+        "no",
+        None,
+        "yes",
+    ]
+
+
+def test_discretize_column_with_get_quantile_based_discretization_function():
+    column = range(1, 6)
+    f = get_quantile_based_discretization_function(column)
+    assert discretize_column(column, f) == [
+        "(a) very low (≤ 2.0)",
+        "(b) low (2.0 - 3.0)",
+        "(c) high (3.0 - 4.0)",
+        "(d) very high (> 4.0)",
+        "(d) very high (> 4.0)",  # that looks weird but is correct. See spot check above, too.
+    ]
+
+
+def test_discretize_column_non_mutable():
+    """Ensure we don't mutate the original column."""
+    column = [1, 2]
+    assert discretize_column(column, DISCRETIZE_BIN) != column
+
+
+def test_discretize_df():
+    df = pl.DataFrame(
+        {"foo": np.linspace(1, 4, 4), "bar": range(5, 9), "baz": ["x", "y", "x", "y"]}
+    )
+    df_expected = pl.DataFrame(
+        {
+            "foo": ["yes", "no", "no", "no"],
+            "bar": ["ja", "ja", "nein", "nein"],
+            "baz": ["x", "y", "x", "y"],
+        }
+    )
+    discretized_df = discretize_df(
+        df,
+        discretization_functions={
+            "foo": DISCRETIZE_BIN,
+            "bar": lambda x: "ja" if x <= 6 else "nein",
+        },
+    )
+    assert_frame_equal(discretized_df, df_expected)
+
+
+def test_discretize_df_non_mutable():
+    df = pl.DataFrame({"foo": [1, 2]})
+    discretized_df = discretize_df(df, discretization_functions={"foo": DISCRETIZE_BIN})
+    assert_frame_not_equal(discretized_df, df)
+
+
+@pytest.mark.parametrize("df_args", [{"foo": ["a"]}, {"bar": range(6)}, None])
+def test_discretize_df_null_op(df_args):
+    df = pl.DataFrame(df_args)
+    discretized_df = discretize_df(df, discretization_functions={})
+    assert_frame_equal(discretized_df,df)
+
+
+# Some constructs used multiple times below.
+_numeric_column = range(1, 6)
+_discrete_column = ["a"] * len(_numeric_column)
+_df_input = pl.DataFrame({"foo": _numeric_column, "bar": _discrete_column})
+
+_df_expected = pl.DataFrame(
+    {
+        "foo": [
+            "(a) very low (≤ 2.0)",
+            "(b) low (2.0 - 3.0)",
+            "(c) high (3.0 - 4.0)",
+            "(d) very high (> 4.0)",
+            "(d) very high (> 4.0)",
+        ],
+        "bar": _discrete_column,
+    }
+)
+
+
+def test_discretize_df_supplying_quantiles():
+    discretized_df = discretize_df(
+        _df_input,
+        discretization_functions={
+            "foo": get_quantile_based_discretization_function(_numeric_column)
+        },
+    )
+    assert_frame_equal(discretized_df, _df_expected)
+
+
+_quantiles_foo = [
+    {"foo": 4},  # explicit dict.
+    4,  # should be turned into dict.
+    None,  # default.
+]
+
+
+@pytest.mark.parametrize("quantiles_foo", _quantiles_foo)
+def test_discretize_df_quantiles(quantiles_foo):
+    discretized_df = discretize_df_quantiles(_df_input, quantiles=quantiles_foo)
+    assert_frame_equal(discretized_df, _df_expected)
+
+
+@pytest.mark.parametrize("quantiles_foo", _quantiles_foo)
+def test_discretize_df_quantiles_set_columns(quantiles_foo):
+    discretized_df = discretize_df_quantiles(
+        _df_input, quantiles=quantiles_foo, columns=["foo"]
+    )
+    assert_frame_equal(discretized_df, _df_expected)
+
+
+def test_discretize_df_quantiles_non_mutable():
+    discretized_df = discretize_df_quantiles(_df_input)
+    assert_frame_not_equal(discretized_df, _df_input)
+
+
+def test_discretize_df_quantiles_non_existing_columns():
+    _assert_raised_AssertionError(discretize_df_quantiles, _df_input, {"quagga": 2})
+
+
+@pytest.mark.parametrize("quantiles_foo", _quantiles_foo)
+def test_discretize_quantiles_smoke(quantiles_foo):
+    discretized_df1, discretized_df2 = discretize_quantiles(
+        [_df_input, _df_input], quantiles=quantiles_foo
+    )
+    assert isinstance(discretized_df1, pl.DataFrame) and isinstance(
+        discretized_df1, pl.DataFrame
+    )
+
+
+_dfs = [
+    pl.DataFrame(
+        {
+            "foo": range(1, 6),
+            "bar": range(5, 10),
+            "baz": _discrete_column,
+        }
+    ),
+    pl.DataFrame(
+        {
+            "foo": [5, 2, 3, 4],
+            "bar": [5, 7, 6, 8],
+            "baz": _discrete_column[:-1],
+        }
+    ),
+]
+
+
+def test_discretize_quantiles_spot_check_int_quartiles():
+    discretized_dfs = discretize_quantiles(_dfs)
+    expected = [
+        pl.DataFrame(
+            {
+                "foo": [
+                    "(a) very low (≤ 2.0)",
+                    "(b) low (2.0 - 3.0)",
+                    "(c) high (3.0 - 4.0)",
+                    "(d) very high (> 4.0)",
+                    "(d) very high (> 4.0)",
+                ],
+                "bar": [
+                    "(a) very low (≤ 6.0)",
+                    "(b) low (6.0 - 7.0)",
+                    "(c) high (7.0 - 8.0)",
+                    "(d) very high (> 8.0)",
+                    "(d) very high (> 8.0)",
+                ],
+                "baz": _discrete_column,
+            }
+        ),
+        pl.DataFrame(
+            {
+                "foo": [
+                    "(d) very high (> 4.0)",
+                    "(b) low (2.0 - 3.0)",
+                    "(c) high (3.0 - 4.0)",
+                    "(d) very high (> 4.0)",
+                ],
+                "bar": [
+                    "(a) very low (≤ 6.0)",
+                    "(c) high (7.0 - 8.0)",
+                    "(b) low (6.0 - 7.0)",
+                    "(d) very high (> 8.0)",
+                ],
+                "baz": _discrete_column[:-1],
+            }
+        ),
+    ]
+    assert_frame_equal(discretized_dfs[0], expected[0])
+    assert_frame_equal(discretized_dfs[1], expected[1])
+
+
+def test_discretize_quantiles_spot_check_quantiles_per_col():
+    discretized_dfs = discretize_quantiles(_dfs, quantiles={"foo": 4, "bar": 2})
+    expected = [
+        pl.DataFrame(
+            {
+                "foo": [
+                    "(a) very low (≤ 2.0)",
+                    "(b) low (2.0 - 3.0)",
+                    "(c) high (3.0 - 4.0)",
+                    "(d) very high (> 4.0)",
+                    "(d) very high (> 4.0)",
+                ],
+                "bar": [
+                    "(a) low (≤ 7.0)",
+                    "(a) low (≤ 7.0)",
+                    "(b) high (> 7.0)",
+                    "(b) high (> 7.0)",
+                    "(b) high (> 7.0)",
+                ],
+                "baz": _discrete_column,
+            }
+        ),
+        pl.DataFrame(
+            {
+                "foo": [
+                    "(d) very high (> 4.0)",
+                    "(b) low (2.0 - 3.0)",
+                    "(c) high (3.0 - 4.0)",
+                    "(d) very high (> 4.0)",
+                ],
+                "bar": [
+                    "(a) low (≤ 7.0)",
+                    "(b) high (> 7.0)",
+                    "(a) low (≤ 7.0)",
+                    "(b) high (> 7.0)",
+                ],
+                "baz": _discrete_column[:-1],
+            }
+        ),
+    ]
+    assert_frame_equal(discretized_dfs[0], expected[0])
+    assert_frame_equal(discretized_dfs[1], expected[1])


### PR DESCRIPTION
Modify the comparison operator in the generated discretization function from `<` to `<=` to reflect the closed upper bounds returned by the Polars qcut() function. Then update 10 of the tests to reflect the expected results of discretization (the others seem to work fine). Also add Ulli's `test_get_quantile_based_discretization_function_skewed()`.