### PR TITLE
fix: Allow duplicates in data and fix discretization comparison

### DIFF
--- a/src/lpm_discretize/discretize.py
+++ b/src/lpm_discretize/discretize.py
@@ -102,7 +102,7 @@ def get_quantile_based_discretization_function(column, quantiles=4, decimals=1):
         set(
             [
                 quantile["breakpoint"]
-                for quantile in pl.Series(column).qcut(quantiles, include_breaks=True)
+                for quantile in pl.Series(column).qcut(quantiles, include_breaks=True, allow_duplicates=True)
             ]
         )
     )
@@ -111,7 +111,7 @@ def get_quantile_based_discretization_function(column, quantiles=4, decimals=1):
         assert not isinstance(value, str)
         if _is_number(value):
             for i, cutoff in enumerate(cutoffs[:-1]):
-                if value < cutoff:
+                if value <= cutoff:
                     if i == 0:
                         return _prefix_category_name(
                             i, len(cutoffs)

--- a/tests/test_discretize.py
+++ b/tests/test_discretize.py
@@ -289,9 +289,9 @@ def test_discretize_column_with_get_quantile_based_discretization_function():
     f = get_quantile_based_discretization_function(column)
     assert discretize_column(column, f) == [
         "(a) very low (≤ 2.0)",
+        "(a) very low (≤ 2.0)",
         "(b) low (2.0 - 3.0)",
         "(c) high (3.0 - 4.0)",
-        "(d) very high (> 4.0)",
         "(d) very high (> 4.0)",  # that looks weird but is correct. See spot check above, too.
     ]
 
@@ -345,9 +345,9 @@ _df_expected = pl.DataFrame(
     {
         "foo": [
             "(a) very low (≤ 2.0)",
+            "(a) very low (≤ 2.0)",
             "(b) low (2.0 - 3.0)",
             "(c) high (3.0 - 4.0)",
-            "(d) very high (> 4.0)",
             "(d) very high (> 4.0)",
         ],
         "bar": _discrete_column,
@@ -430,16 +430,16 @@ def test_discretize_quantiles_spot_check_int_quartiles():
             {
                 "foo": [
                     "(a) very low (≤ 2.0)",
+                    "(a) very low (≤ 2.0)",
                     "(b) low (2.0 - 3.0)",
                     "(c) high (3.0 - 4.0)",
-                    "(d) very high (> 4.0)",
                     "(d) very high (> 4.0)",
                 ],
                 "bar": [
                     "(a) very low (≤ 6.0)",
+                    "(a) very low (≤ 6.0)",
                     "(b) low (6.0 - 7.0)",
                     "(c) high (7.0 - 8.0)",
-                    "(d) very high (> 8.0)",
                     "(d) very high (> 8.0)",
                 ],
                 "baz": _discrete_column,
@@ -449,15 +449,15 @@ def test_discretize_quantiles_spot_check_int_quartiles():
             {
                 "foo": [
                     "(d) very high (> 4.0)",
+                    "(a) very low (≤ 2.0)",
                     "(b) low (2.0 - 3.0)",
                     "(c) high (3.0 - 4.0)",
-                    "(d) very high (> 4.0)",
                 ],
                 "bar": [
                     "(a) very low (≤ 6.0)",
-                    "(c) high (7.0 - 8.0)",
                     "(b) low (6.0 - 7.0)",
-                    "(d) very high (> 8.0)",
+                    "(a) very low (≤ 6.0)",
+                    "(c) high (7.0 - 8.0)",
                 ],
                 "baz": _discrete_column[:-1],
             }
@@ -474,15 +474,15 @@ def test_discretize_quantiles_spot_check_quantiles_per_col():
             {
                 "foo": [
                     "(a) very low (≤ 2.0)",
+                    "(a) very low (≤ 2.0)",
                     "(b) low (2.0 - 3.0)",
                     "(c) high (3.0 - 4.0)",
-                    "(d) very high (> 4.0)",
                     "(d) very high (> 4.0)",
                 ],
                 "bar": [
                     "(a) low (≤ 7.0)",
                     "(a) low (≤ 7.0)",
-                    "(b) high (> 7.0)",
+                    "(a) low (≤ 7.0)",
                     "(b) high (> 7.0)",
                     "(b) high (> 7.0)",
                 ],
@@ -493,13 +493,13 @@ def test_discretize_quantiles_spot_check_quantiles_per_col():
             {
                 "foo": [
                     "(d) very high (> 4.0)",
+                    "(a) very low (≤ 2.0)",
                     "(b) low (2.0 - 3.0)",
                     "(c) high (3.0 - 4.0)",
-                    "(d) very high (> 4.0)",
                 ],
                 "bar": [
                     "(a) low (≤ 7.0)",
-                    "(b) high (> 7.0)",
+                    "(a) low (≤ 7.0)",
                     "(a) low (≤ 7.0)",
                     "(b) high (> 7.0)",
                 ],
@@ -509,3 +509,8 @@ def test_discretize_quantiles_spot_check_quantiles_per_col():
     ]
     assert_frame_equal(discretized_dfs[0], expected[0])
     assert_frame_equal(discretized_dfs[1], expected[1])
+
+def test_get_quantile_based_discretization_function_skewed():
+    column = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 20, 20]
+    f = get_quantile_based_discretization_function(column, quantiles=6)
+    assert f(0) == "(a) low (≤ 0.0)"


### PR DESCRIPTION
**What does this do?**

Allows duplicates in Polars `qcut()` operations on a columns being discretized.
Changes the comparison operator in the discretization function from `< `to `<=` for closed interval upper bound
Updates the tests to expect correct discretizations now that the comparison operator is changed
Add Ulli's new `test_get_quantile_based_discretization_function_skewed()`

**Why do we want this?**

In practice, duplicates frequently appear in columns to be discretized, so we need qcut() to handle those properly, otherwise we get runtime errors that prevent discretization. The comparision operator change is just for consistency with the form of the intervals returned by `qcut()`, which by default have open lower bounds and closed upper bounds, so the cutoff comparison against upper bounds needs to use `<=`. The new test case verifies that we do the discretization properly now that `allow_duplicates` is enabled.

**How was this tested?**

Ulli created a new test `test_get_quantile_based_discretization_function_skewed()` which now passes. Updates to 10 of the remaining tests allow those to pass as well.